### PR TITLE
fix(SchemaBuilder): use options.resolvers if exists

### DIFF
--- a/lib/SchemaBuilder.ts
+++ b/lib/SchemaBuilder.ts
@@ -21,9 +21,9 @@ export class SchemaBuilder {
       const scalars = this.scalarsExplorerService.explore();
       const schema = await buildSchema({
         emitSchemaFile: true,
-        ...options,
         // typegraphql have a validation that cannot send an empty resolvers array or an empty string to it
         resolvers: ['**/*.undfined.undfiend.js'],
+        ...options,
         scalarsMap: scalars,
       });
 


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
When using SchemaBuilder with `options.resolvers` this option is not take and it's override by the value `['**/*.undfined.undfiend.js']`

Issue Number: N/A


## What is the new behavior?
Now the `options.resolvers` is used if set.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information